### PR TITLE
Add new metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@librechat/data-schemas": "^0.0.31",
+        "@librechat/data-schemas": "^0.0.50",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
-        "librechat-data-provider": "^0.8.20",
+        "librechat-data-provider": "^0.8.501",
         "mongoose": "^8.18.1",
         "prom-client": "^15.1.3"
       },
@@ -379,15 +379,15 @@
       }
     },
     "node_modules/@librechat/data-schemas": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/@librechat/data-schemas/-/data-schemas-0.0.31.tgz",
-      "integrity": "sha512-I943vRNXD072nV/UaIEAvj5YB+mRBgozWyrQmh8OIzuvsgPyaaVGolrk687IvHi9Aq/JAlKr7h8FsMqh8UiN2w==",
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@librechat/data-schemas/-/data-schemas-0.0.50.tgz",
+      "integrity": "sha512-xIaW8YigXLwsKdr8DfOyHd7v5DfSl30YoQh4GHm2vCcGPBM4w4bsMwpdAVzbGRc88xPNK0XN1Qc8xiW2bX04Nw==",
       "license": "MIT",
       "peerDependencies": {
         "jsonwebtoken": "^9.0.2",
         "klona": "^2.0.6",
         "librechat-data-provider": "*",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "meilisearch": "^0.38.0",
         "mongoose": "^8.12.1",
         "nanoid": "^3.3.7",
@@ -1535,14 +1535,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2820,9 +2820,9 @@
       "peer": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3879,14 +3879,14 @@
       }
     },
     "node_modules/librechat-data-provider": {
-      "version": "0.8.20",
-      "resolved": "https://registry.npmjs.org/librechat-data-provider/-/librechat-data-provider-0.8.20.tgz",
-      "integrity": "sha512-OS+/ysvnDkKkJUFQ+MPpv6r8GiF/1H4tmy3MK1FBYwYe8WltO8vfYiyf5pPATBzVMtYqhDZQO2Qsy9CN3F0uEA==",
+      "version": "0.8.501",
+      "resolved": "https://registry.npmjs.org/librechat-data-provider/-/librechat-data-provider-0.8.501.tgz",
+      "integrity": "sha512-vHvMs8SEL0ez8f3hksPr3csizS6LLCADZ787i1cVDCJHgy2L0QHOHR1jyU5vJKk/2CleGjbavPc7IE1NjaYX2Q==",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.12.1",
+        "axios": "^1.15.0",
         "dayjs": "^1.11.13",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "zod": "^3.22.4"
       },
       "peerDependencies": {
@@ -3910,9 +3910,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -4625,10 +4625,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/rubentalstra/librechat-prom-exporter#readme",
   "dependencies": {
-    "@librechat/data-schemas": "^0.0.31",
+    "@librechat/data-schemas": "^0.0.50",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
-    "librechat-data-provider": "^0.8.20",
+    "librechat-data-provider": "^0.8.501",
     "mongoose": "^8.18.1",
     "prom-client": "^15.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -48,6 +48,34 @@ export const advancedGauges = {
         help: 'Count of messages with thumbs down feedback',
         labelNames: ['tag', 'model'],
     }),
+    messageFeedbackThumbsUpTotal: new client.Gauge({
+        name: 'librechat_message_feedback_thumbs_up_total',
+        help: 'Total count of messages with thumbs up feedback',
+    }),
+    messageFeedbackThumbsDownTotal: new client.Gauge({
+        name: 'librechat_message_feedback_thumbs_down_total',
+        help: 'Total count of messages with thumbs down feedback',
+    }),
+    feedbackThumbsUpPercentByModel30d: new client.Gauge({
+        name: 'librechat_feedback_thumbs_up_percent_by_model_30d',
+        help: 'Percentage of messages with thumbs up feedback per model (last 30 days)',
+        labelNames: ['model'],
+    }),
+    feedbackThumbsDownPercentByModel30d: new client.Gauge({
+        name: 'librechat_feedback_thumbs_down_percent_by_model_30d',
+        help: 'Percentage of messages with thumbs down feedback per model (last 30 days)',
+        labelNames: ['model'],
+    }),
+    feedbackThumbsUpPercentByAgent30d: new client.Gauge({
+        name: 'librechat_feedback_thumbs_up_percent_by_agent_30d',
+        help: 'Percentage of messages with thumbs up feedback per agent (last 30 days)',
+        labelNames: ['agent'],
+    }),
+    feedbackThumbsDownPercentByAgent30d: new client.Gauge({
+        name: 'librechat_feedback_thumbs_down_percent_by_agent_30d',
+        help: 'Percentage of messages with thumbs down feedback per agent (last 30 days)',
+        labelNames: ['agent'],
+    }),
 
     // Banner metrics
     activeBannerCount: new client.Gauge({
@@ -214,6 +242,45 @@ export const advancedGauges = {
         name: 'librechat_deployed_model_names_count',
         help: 'Total number of distinct deployed model names found in messages',
     }),
+
+    // Internal user metrics
+    internalAdoptionRate30d: new client.Gauge({
+        name: 'librechat_internal_adoption_rate_30d',
+        help: 'Percentage of internal (NOS group) unique users vs total unique users in the last 30 days',
+    }),
+
+    // Adoption rate metrics
+    adoptionRate1d: new client.Gauge({
+        name: 'librechat_adoption_rate_1d',
+        help: 'Percentage of active users (last 1 day) vs total registered users',
+    }),
+    adoptionRate7d: new client.Gauge({
+        name: 'librechat_adoption_rate_7d',
+        help: 'Percentage of active users (last 7 days) vs total registered users',
+    }),
+    adoptionRate30d: new client.Gauge({
+        name: 'librechat_adoption_rate_30d',
+        help: 'Percentage of active users (last 30 days) vs total registered users',
+    }),
+
+    // MCP utilization metrics (30 days)
+    mcpToolCallCount30d: new client.Gauge({
+        name: 'librechat_mcp_tool_call_count_30d',
+        help: 'Total MCP tool calls in the last 30 days',
+    }),
+    mcpToolCallCountByTool30d: new client.Gauge({
+        name: 'librechat_mcp_tool_call_count_by_tool_30d',
+        help: 'MCP tool calls in the last 30 days by toolId',
+        labelNames: ['toolId'],
+    }),
+    mcpUniqueUserCount30d: new client.Gauge({
+        name: 'librechat_mcp_unique_users_30d',
+        help: 'Unique users using MCP tools in the last 30 days',
+    }),
+    mcpUtilizationPercent30d: new client.Gauge({
+        name: 'librechat_mcp_utilization_percent_30d',
+        help: 'Percentage of tool calls that are MCP in the last 30 days',
+    }),
 };
 
 /**
@@ -304,6 +371,12 @@ export async function updateAdvancedMetrics(): Promise<void> {
             totalMsgCount > 0 ? (pluginUsageCount / totalMsgCount) * 100 : 0;
         advancedGauges.messagePluginUsagePercent.set(pluginUsagePercent);
 
+        // Set feedback totals
+        const thumbsUpTotal = thumbsUpByTagAgg.reduce((sum: number, r: { count: number }) => sum + r.count, 0);
+        const thumbsDownTotal = thumbsDownByTagAgg.reduce((sum: number, r: { count: number }) => sum + r.count, 0);
+        advancedGauges.messageFeedbackThumbsUpTotal.set(thumbsUpTotal);
+        advancedGauges.messageFeedbackThumbsDownTotal.set(thumbsDownTotal);
+
         // Set feedback metrics by tag and model
         advancedGauges.messageFeedbackThumbsUpCount.reset();
         for (const result of thumbsUpByTagAgg) {
@@ -375,7 +448,10 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.activeUserCount.set(activeUsers);
 
         // --- Unique Users ---
-        const uniqueUsers = await Message.distinct('user');
+        const [uniqueUsers, totalUserCount] = await Promise.all([
+            Message.distinct('user'),
+            User.countDocuments({}),
+        ]);
         advancedGauges.uniqueUserCount.set(uniqueUsers.length);
 
         // --- Unique Users in Sliding Windows (1, 7 and 30 days) ---
@@ -392,6 +468,17 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.uniqueUserCount1d.set(uniqueUsers1d.length);
         advancedGauges.uniqueUserCount7d.set(uniqueUsers7d.length);
         advancedGauges.uniqueUserCount30d.set(uniqueUsers30d.length);
+
+        // --- Adoption Rates (active users / total users) ---
+        advancedGauges.adoptionRate1d.set(
+            totalUserCount > 0 ? (uniqueUsers1d.length / totalUserCount) * 100 : 0,
+        );
+        advancedGauges.adoptionRate7d.set(
+            totalUserCount > 0 ? (uniqueUsers7d.length / totalUserCount) * 100 : 0,
+        );
+        advancedGauges.adoptionRate30d.set(
+            totalUserCount > 0 ? (uniqueUsers30d.length / totalUserCount) * 100 : 0,
+        );
 
         // --- Combined Active/Unique Users by Email Domain (5min, 1d, 7d, 30d) ---
         const usersByDomainResults = await Message.aggregate([
@@ -564,8 +651,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.transactionCostTotalUSD.set(totalCost);
 
         // Cost per user.
-        const userCount = await User.countDocuments({});
-        const costPerUser = userCount > 0 ? totalCost / userCount : 0;
+        const costPerUser = totalUserCount > 0 ? totalCost / totalUserCount : 0;
         advancedGauges.transactionCostPerUser.set(costPerUser);
 
         // Cost per deployed model.
@@ -617,6 +703,47 @@ export async function updateAdvancedMetrics(): Promise<void> {
             }
         }
 
+        // --- Feedback Percentage by Model / Agent (30 days) ---
+        // Only assistant-generated messages (isCreatedByUser: false) are eligible for feedback.
+        const feedbackByModel30dAgg = await Message.aggregate([
+            { $match: { createdAt: { $gte: thirtyDaysAgo }, model: { $ne: null }, isCreatedByUser: false } },
+            {
+                $group: {
+                    _id: '$model',
+                    total: { $sum: 1 },
+                    thumbsUp: {
+                        $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsUp'] }, 1, 0] },
+                    },
+                    thumbsDown: {
+                        $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsDown'] }, 1, 0] },
+                    },
+                },
+            },
+        ]);
+
+        advancedGauges.feedbackThumbsUpPercentByModel30d.reset();
+        advancedGauges.feedbackThumbsDownPercentByModel30d.reset();
+        advancedGauges.feedbackThumbsUpPercentByAgent30d.reset();
+        advancedGauges.feedbackThumbsDownPercentByAgent30d.reset();
+
+        for (const result of feedbackByModel30dAgg) {
+            const id: string = result._id;
+            const total: number = result.total;
+            if (total === 0) continue;
+
+            const upPct = (result.thumbsUp / total) * 100;
+            const downPct = (result.thumbsDown / total) * 100;
+
+            if (id.startsWith('agent_')) {
+                const displayName = agentMap.get(id) || id;
+                advancedGauges.feedbackThumbsUpPercentByAgent30d.set({ agent: displayName }, upPct);
+                advancedGauges.feedbackThumbsDownPercentByAgent30d.set({ agent: displayName }, downPct);
+            } else if (!id.startsWith('assistant_')) {
+                advancedGauges.feedbackThumbsUpPercentByModel30d.set({ model: id }, upPct);
+                advancedGauges.feedbackThumbsDownPercentByModel30d.set({ model: id }, downPct);
+            }
+        }
+
         // Count distinct deployed model names (excluding agents/assistants).
         const distinctModelsAgg = await Message.aggregate([
             { $match: { model: { $ne: null } } },
@@ -627,6 +754,70 @@ export async function updateAdvancedMetrics(): Promise<void> {
             return !id.startsWith('agent_') && !id.startsWith('assistant_');
         });
         advancedGauges.deployedModelNamesCount.set(filteredDistinctModels.length);
+
+        // --- Internal Adoption Rate (30 days) ---
+        const internalDomains = new Set(['nos.pt', 'nos-acores.pt', 'nosmadeira.pt', 'tentwentyone.io', 'lojas.nos.pt', 'corporativo.pt']);
+        const internalUniqueUsers30d = uniqueUsers30dByDomainAgg
+            .filter((r: { domain: string; count: number }) => internalDomains.has(r.domain))
+            .reduce((sum: number, r: { count: number }) => sum + r.count, 0);
+        const totalUniqueUsers30d = uniqueUsers30d.length;
+        advancedGauges.internalAdoptionRate30d.set(
+            totalUniqueUsers30d > 0 ? (internalUniqueUsers30d / totalUniqueUsers30d) * 100 : 0,
+        );
+
+        // --- MCP Utilization Metrics (30 days) ---
+        // MCP tool calls are NOT stored in the toolcalls collection.
+        // They are embedded as content parts (type: 'tool_call') within messages.
+        const toolCallContentAgg = await Message.aggregate([
+            { $match: { createdAt: { $gte: thirtyDaysAgo }, 'content.type': 'tool_call' } },
+            { $unwind: '$content' },
+            { $match: { 'content.type': 'tool_call' } },
+            {
+                $addFields: {
+                    toolName: {
+                        $ifNull: [
+                            '$content.tool_call.name',
+                            { $ifNull: ['$content.tool_call.function.name', 'unknown'] },
+                        ],
+                    },
+                },
+            },
+            {
+                $facet: {
+                    totalToolCalls: [{ $count: 'count' }],
+                    mcpTotal: [
+                        { $match: { toolName: { $regex: '_mcp_' } } },
+                        { $count: 'count' },
+                    ],
+                    mcpByTool: [
+                        { $match: { toolName: { $regex: '_mcp_' } } },
+                        { $group: { _id: '$toolName', count: { $sum: 1 } } },
+                    ],
+                    mcpUniqueUsers: [
+                        { $match: { toolName: { $regex: '_mcp_' } } },
+                        { $group: { _id: '$user' } },
+                        { $count: 'count' },
+                    ],
+                },
+            },
+        ]);
+
+        const totalToolCalls30d = toolCallContentAgg[0]?.totalToolCalls[0]?.count || 0;
+        const mcpTotal = toolCallContentAgg[0]?.mcpTotal[0]?.count || 0;
+        const mcpByTool = toolCallContentAgg[0]?.mcpByTool || [];
+        const mcpUsers = toolCallContentAgg[0]?.mcpUniqueUsers[0]?.count || 0;
+
+        advancedGauges.mcpToolCallCount30d.set(mcpTotal);
+
+        advancedGauges.mcpToolCallCountByTool30d.reset();
+        for (const result of mcpByTool) {
+            advancedGauges.mcpToolCallCountByTool30d.set({ toolId: result._id }, result.count);
+        }
+
+        advancedGauges.mcpUniqueUserCount30d.set(mcpUsers);
+        advancedGauges.mcpUtilizationPercent30d.set(
+            totalToolCalls30d > 0 ? (mcpTotal / totalToolCalls30d) * 100 : 0,
+        );
 
         console.log('Advanced metrics updated.');
     } catch (error) {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -76,6 +76,20 @@ export const advancedGauges = {
         help: 'Percentage of messages with thumbs down feedback per agent (last 30 days)',
         labelNames: ['agent'],
     }),
+    feedbackEngagementRate30d: new client.Gauge({
+        name: 'librechat_feedback_engagement_rate_30d',
+        help: 'Percentage of assistant messages (last 30 days) that received any feedback',
+    }),
+    netSatisfactionByModel30d: new client.Gauge({
+        name: 'librechat_net_satisfaction_by_model_30d',
+        help: 'Net satisfaction score per model (last 30 days): (thumbsUp - thumbsDown) / total * 100',
+        labelNames: ['model'],
+    }),
+    netSatisfactionByAgent30d: new client.Gauge({
+        name: 'librechat_net_satisfaction_by_agent_30d',
+        help: 'Net satisfaction score per agent (last 30 days): (thumbsUp - thumbsDown) / total * 100',
+        labelNames: ['agent'],
+    }),
 
     // Banner metrics
     activeBannerCount: new client.Gauge({
@@ -112,6 +126,11 @@ export const advancedGauges = {
     userCountByDomain: new client.Gauge({
         name: 'librechat_user_count_by_email_domain',
         help: 'Number of users grouped by email domain',
+        labelNames: ['email_domain'],
+    }),
+    userPercentByDomain30d: new client.Gauge({
+        name: 'librechat_user_percent_by_email_domain_30d',
+        help: 'Percentage of active users by email domain (last 30 days)',
         labelNames: ['email_domain'],
     }),
 
@@ -243,17 +262,7 @@ export const advancedGauges = {
         help: 'Total number of distinct deployed model names found in messages',
     }),
 
-    // Internal user metrics
-    internalAdoptionRate30d: new client.Gauge({
-        name: 'librechat_internal_adoption_rate_30d',
-        help: 'Percentage of internal (NOS group) unique users vs total unique users in the last 30 days',
-    }),
-
-    // Adoption rate metrics
-    adoptionRate1d: new client.Gauge({
-        name: 'librechat_adoption_rate_1d',
-        help: 'Percentage of active users (last 1 day) vs total registered users',
-    }),
+    // Adoption rate metrics (1d omitted — equivalent to periodicityDaily)
     adoptionRate7d: new client.Gauge({
         name: 'librechat_adoption_rate_7d',
         help: 'Percentage of active users (last 7 days) vs total registered users',
@@ -261,6 +270,20 @@ export const advancedGauges = {
     adoptionRate30d: new client.Gauge({
         name: 'librechat_adoption_rate_30d',
         help: 'Percentage of active users (last 30 days) vs total registered users',
+    }),
+
+    // Usage periodicity metrics
+    periodicityDaily: new client.Gauge({
+        name: 'librechat_periodicity_daily',
+        help: 'Percentage of registered users active today (last 24h)',
+    }),
+    periodicityWeekly: new client.Gauge({
+        name: 'librechat_periodicity_weekly',
+        help: 'Percentage of registered users active 3+ days in the last 7 days',
+    }),
+    periodicityMonthly: new client.Gauge({
+        name: 'librechat_periodicity_monthly',
+        help: 'Percentage of registered users active 5+ days in the last 30 days',
     }),
 
     // MCP utilization metrics (30 days)
@@ -470,14 +493,46 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.uniqueUserCount30d.set(uniqueUsers30d.length);
 
         // --- Adoption Rates (active users / total users) ---
-        advancedGauges.adoptionRate1d.set(
-            totalUserCount > 0 ? (uniqueUsers1d.length / totalUserCount) * 100 : 0,
-        );
+        // Note: 1d adoption rate is identical to periodicityDaily and emitted there.
         advancedGauges.adoptionRate7d.set(
             totalUserCount > 0 ? (uniqueUsers7d.length / totalUserCount) * 100 : 0,
         );
         advancedGauges.adoptionRate30d.set(
             totalUserCount > 0 ? (uniqueUsers30d.length / totalUserCount) * 100 : 0,
+        );
+
+        // --- Usage Periodicity Metrics ---
+        // Daily: % of registered users active today
+        advancedGauges.periodicityDaily.set(
+            totalUserCount > 0 ? (uniqueUsers1d.length / totalUserCount) * 100 : 0,
+        );
+
+        // Weekly: % of registered users with 3+ active days in the last 7 days
+        // Monthly: % of registered users with 5+ active days in the last 30 days
+        const [weeklyPeriodicityAgg, monthlyPeriodicityAgg] = await Promise.all([
+            Message.aggregate([
+                { $match: { createdAt: { $gte: sevenDaysAgo } } },
+                { $group: { _id: { user: '$user', day: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } } } } },
+                { $group: { _id: '$_id.user', activeDays: { $sum: 1 } } },
+                { $match: { activeDays: { $gte: 3 } } },
+                { $count: 'count' },
+            ]),
+            Message.aggregate([
+                { $match: { createdAt: { $gte: thirtyDaysAgo } } },
+                { $group: { _id: { user: '$user', day: { $dateToString: { format: '%Y-%m-%d', date: '$createdAt' } } } } },
+                { $group: { _id: '$_id.user', activeDays: { $sum: 1 } } },
+                { $match: { activeDays: { $gte: 5 } } },
+                { $count: 'count' },
+            ]),
+        ]);
+
+        const weeklyPeriodicityCount = weeklyPeriodicityAgg[0]?.count || 0;
+        const monthlyPeriodicityCount = monthlyPeriodicityAgg[0]?.count || 0;
+        advancedGauges.periodicityWeekly.set(
+            totalUserCount > 0 ? (weeklyPeriodicityCount / totalUserCount) * 100 : 0,
+        );
+        advancedGauges.periodicityMonthly.set(
+            totalUserCount > 0 ? (monthlyPeriodicityCount / totalUserCount) * 100 : 0,
         );
 
         // --- Combined Active/Unique Users by Email Domain (5min, 1d, 7d, 30d) ---
@@ -497,7 +552,12 @@ export async function updateAdvancedMetrics(): Promise<void> {
         ]);
 
         // Process results and set metrics
-        const [activeUsersByDomainAgg, uniqueUsers1dByDomainAgg, uniqueUsers7dByDomainAgg, uniqueUsers30dByDomainAgg] = [
+        const [
+            activeUsersByDomainAgg,
+            uniqueUsers1dByDomainAgg,
+            uniqueUsers7dByDomainAgg,
+            uniqueUsers30dByDomainAgg,
+        ] = [
             usersByDomainResults[0]?.active5min || [],
             usersByDomainResults[0]?.unique1d || [],
             usersByDomainResults[0]?.unique7d || [],
@@ -522,6 +582,18 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.uniqueUserCount30dByDomain.reset();
         for (const result of uniqueUsers30dByDomainAgg) {
             advancedGauges.uniqueUserCount30dByDomain.set({ email_domain: result.domain }, result.count);
+        }
+
+        // --- User Percent By Email Domain (30 days) ---
+        const totalUniqueUsers30d = uniqueUsers30dByDomainAgg.reduce(
+            (sum: number, r: { count: number }) => sum + r.count, 0,
+        );
+        advancedGauges.userPercentByDomain30d.reset();
+        for (const result of uniqueUsers30dByDomainAgg) {
+            advancedGauges.userPercentByDomain30d.set(
+                { email_domain: result.domain },
+                totalUniqueUsers30d > 0 ? (result.count / totalUniqueUsers30d) * 100 : 0,
+            );
         }
 
         // --- Session Metrics ---
@@ -703,105 +775,117 @@ export async function updateAdvancedMetrics(): Promise<void> {
             }
         }
 
-        // --- Feedback Percentage by Model / Agent (30 days) ---
-        // Only assistant-generated messages (isCreatedByUser: false) are eligible for feedback.
-        const feedbackByModel30dAgg = await Message.aggregate([
-            { $match: { createdAt: { $gte: thirtyDaysAgo }, model: { $ne: null }, isCreatedByUser: false } },
-            {
-                $group: {
-                    _id: '$model',
-                    total: { $sum: 1 },
-                    thumbsUp: {
-                        $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsUp'] }, 1, 0] },
-                    },
-                    thumbsDown: {
-                        $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsDown'] }, 1, 0] },
+        // --- Parallelized: Feedback, Distinct Models, MCP (independent queries) ---
+        const [feedbackByModel30dAgg, distinctModelsAgg, toolCallContentAgg] = await Promise.all([
+            // Feedback by model/agent (30d) — only assistant messages are eligible
+            Message.aggregate([
+                { $match: { createdAt: { $gte: thirtyDaysAgo }, model: { $ne: null }, isCreatedByUser: false } },
+                {
+                    $group: {
+                        _id: '$model',
+                        total: { $sum: 1 },
+                        thumbsUp: {
+                            $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsUp'] }, 1, 0] },
+                        },
+                        thumbsDown: {
+                            $sum: { $cond: [{ $eq: ['$feedback.rating', 'thumbsDown'] }, 1, 0] },
+                        },
                     },
                 },
-            },
+            ]),
+            // Distinct deployed model names
+            Message.aggregate([
+                { $match: { model: { $ne: null } } },
+                { $group: { _id: '$model' } },
+            ]),
+            // MCP tool call content (30d)
+            Message.aggregate([
+                { $match: { createdAt: { $gte: thirtyDaysAgo }, 'content.type': 'tool_call' } },
+                { $unwind: '$content' },
+                { $match: { 'content.type': 'tool_call' } },
+                {
+                    $addFields: {
+                        toolName: {
+                            $ifNull: [
+                                '$content.tool_call.name',
+                                { $ifNull: ['$content.tool_call.function.name', 'unknown'] },
+                            ],
+                        },
+                    },
+                },
+                {
+                    $facet: {
+                        totalToolCalls: [{ $count: 'count' }],
+                        mcpTotal: [
+                            { $match: { toolName: { $regex: '_mcp_' } } },
+                            { $count: 'count' },
+                        ],
+                        mcpByTool: [
+                            { $match: { toolName: { $regex: '_mcp_' } } },
+                            { $group: { _id: '$toolName', count: { $sum: 1 } } },
+                        ],
+                        mcpUniqueUsers: [
+                            { $match: { toolName: { $regex: '_mcp_' } } },
+                            { $group: { _id: '$user' } },
+                            { $count: 'count' },
+                        ],
+                    },
+                },
+            ]),
         ]);
 
+        // --- Feedback Percentage + Net Satisfaction by Model / Agent (30 days) ---
         advancedGauges.feedbackThumbsUpPercentByModel30d.reset();
         advancedGauges.feedbackThumbsDownPercentByModel30d.reset();
         advancedGauges.feedbackThumbsUpPercentByAgent30d.reset();
         advancedGauges.feedbackThumbsDownPercentByAgent30d.reset();
+        advancedGauges.netSatisfactionByModel30d.reset();
+        advancedGauges.netSatisfactionByAgent30d.reset();
+
+        let totalAssistantMessages30d = 0;
+        let totalFeedbackMessages30d = 0;
 
         for (const result of feedbackByModel30dAgg) {
             const id: string = result._id;
             const total: number = result.total;
-            if (total === 0) continue;
+            if (total === 0) {
+                continue;
+            }
+
+            totalAssistantMessages30d += total;
+            totalFeedbackMessages30d += result.thumbsUp + result.thumbsDown;
 
             const upPct = (result.thumbsUp / total) * 100;
             const downPct = (result.thumbsDown / total) * 100;
+            const netSatisfaction = ((result.thumbsUp - result.thumbsDown) / total) * 100;
 
             if (id.startsWith('agent_')) {
                 const displayName = agentMap.get(id) || id;
                 advancedGauges.feedbackThumbsUpPercentByAgent30d.set({ agent: displayName }, upPct);
                 advancedGauges.feedbackThumbsDownPercentByAgent30d.set({ agent: displayName }, downPct);
+                advancedGauges.netSatisfactionByAgent30d.set({ agent: displayName }, netSatisfaction);
             } else if (!id.startsWith('assistant_')) {
                 advancedGauges.feedbackThumbsUpPercentByModel30d.set({ model: id }, upPct);
                 advancedGauges.feedbackThumbsDownPercentByModel30d.set({ model: id }, downPct);
+                advancedGauges.netSatisfactionByModel30d.set({ model: id }, netSatisfaction);
             }
         }
 
-        // Count distinct deployed model names (excluding agents/assistants).
-        const distinctModelsAgg = await Message.aggregate([
-            { $match: { model: { $ne: null } } },
-            { $group: { _id: '$model' } },
-        ]);
+        // Feedback engagement rate: % of assistant messages that received any feedback
+        advancedGauges.feedbackEngagementRate30d.set(
+            totalAssistantMessages30d > 0
+                ? (totalFeedbackMessages30d / totalAssistantMessages30d) * 100
+                : 0,
+        );
+
+        // --- Distinct Deployed Model Names ---
         const filteredDistinctModels = distinctModelsAgg.filter((doc: { _id: string }) => {
             const id: string = doc._id;
             return !id.startsWith('agent_') && !id.startsWith('assistant_');
         });
         advancedGauges.deployedModelNamesCount.set(filteredDistinctModels.length);
 
-        // --- Internal Adoption Rate (30 days) ---
-        const internalDomains = new Set(['nos.pt', 'nos-acores.pt', 'nosmadeira.pt', 'tentwentyone.io', 'lojas.nos.pt', 'corporativo.pt']);
-        const internalUniqueUsers30d = uniqueUsers30dByDomainAgg
-            .filter((r: { domain: string; count: number }) => internalDomains.has(r.domain))
-            .reduce((sum: number, r: { count: number }) => sum + r.count, 0);
-        const totalUniqueUsers30d = uniqueUsers30d.length;
-        advancedGauges.internalAdoptionRate30d.set(
-            totalUniqueUsers30d > 0 ? (internalUniqueUsers30d / totalUniqueUsers30d) * 100 : 0,
-        );
-
         // --- MCP Utilization Metrics (30 days) ---
-        // MCP tool calls are NOT stored in the toolcalls collection.
-        // They are embedded as content parts (type: 'tool_call') within messages.
-        const toolCallContentAgg = await Message.aggregate([
-            { $match: { createdAt: { $gte: thirtyDaysAgo }, 'content.type': 'tool_call' } },
-            { $unwind: '$content' },
-            { $match: { 'content.type': 'tool_call' } },
-            {
-                $addFields: {
-                    toolName: {
-                        $ifNull: [
-                            '$content.tool_call.name',
-                            { $ifNull: ['$content.tool_call.function.name', 'unknown'] },
-                        ],
-                    },
-                },
-            },
-            {
-                $facet: {
-                    totalToolCalls: [{ $count: 'count' }],
-                    mcpTotal: [
-                        { $match: { toolName: { $regex: '_mcp_' } } },
-                        { $count: 'count' },
-                    ],
-                    mcpByTool: [
-                        { $match: { toolName: { $regex: '_mcp_' } } },
-                        { $group: { _id: '$toolName', count: { $sum: 1 } } },
-                    ],
-                    mcpUniqueUsers: [
-                        { $match: { toolName: { $regex: '_mcp_' } } },
-                        { $group: { _id: '$user' } },
-                        { $count: 'count' },
-                    ],
-                },
-            },
-        ]);
-
         const totalToolCalls30d = toolCallContentAgg[0]?.totalToolCalls[0]?.count || 0;
         const mcpTotal = toolCallContentAgg[0]?.mcpTotal[0]?.count || 0;
         const mcpByTool = toolCallContentAgg[0]?.mcpByTool || [];

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -307,6 +307,14 @@ export const advancedGauges = {
 };
 
 /**
+ * Returns the percentage of `numerator` over `denominator`.
+ * Returns 0 when denominator is 0 to avoid division-by-zero.
+ */
+function toPercent(numerator: number, denominator: number): number {
+    return denominator > 0 ? (numerator / denominator) * 100 : 0;
+}
+
+/**
  * Helper function to create aggregation pipeline for users by email domain
  * @param timeFilter - Date filter for createdAt field
  * @returns Array of aggregation pipeline stages
@@ -390,8 +398,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
         advancedGauges.messageTokenAvg.set(tokenAvgAgg[0]?.avg || 0);
         advancedGauges.errorMessageCount.set(errorCount);
         advancedGauges.messageWithAttachmentsCount.set(msgWithAttachCount);
-        const pluginUsagePercent =
-            totalMsgCount > 0 ? (pluginUsageCount / totalMsgCount) * 100 : 0;
+        const pluginUsagePercent = toPercent(pluginUsageCount, totalMsgCount);
         advancedGauges.messagePluginUsagePercent.set(pluginUsagePercent);
 
         // Set feedback totals
@@ -494,18 +501,12 @@ export async function updateAdvancedMetrics(): Promise<void> {
 
         // --- Adoption Rates (active users / total users) ---
         // Note: 1d adoption rate is identical to periodicityDaily and emitted there.
-        advancedGauges.adoptionRate7d.set(
-            totalUserCount > 0 ? (uniqueUsers7d.length / totalUserCount) * 100 : 0,
-        );
-        advancedGauges.adoptionRate30d.set(
-            totalUserCount > 0 ? (uniqueUsers30d.length / totalUserCount) * 100 : 0,
-        );
+        advancedGauges.adoptionRate7d.set(toPercent(uniqueUsers7d.length, totalUserCount));
+        advancedGauges.adoptionRate30d.set(toPercent(uniqueUsers30d.length, totalUserCount));
 
         // --- Usage Periodicity Metrics ---
         // Daily: % of registered users active today
-        advancedGauges.periodicityDaily.set(
-            totalUserCount > 0 ? (uniqueUsers1d.length / totalUserCount) * 100 : 0,
-        );
+        advancedGauges.periodicityDaily.set(toPercent(uniqueUsers1d.length, totalUserCount));
 
         // Weekly: % of registered users with 3+ active days in the last 7 days
         // Monthly: % of registered users with 5+ active days in the last 30 days
@@ -528,12 +529,8 @@ export async function updateAdvancedMetrics(): Promise<void> {
 
         const weeklyPeriodicityCount = weeklyPeriodicityAgg[0]?.count || 0;
         const monthlyPeriodicityCount = monthlyPeriodicityAgg[0]?.count || 0;
-        advancedGauges.periodicityWeekly.set(
-            totalUserCount > 0 ? (weeklyPeriodicityCount / totalUserCount) * 100 : 0,
-        );
-        advancedGauges.periodicityMonthly.set(
-            totalUserCount > 0 ? (monthlyPeriodicityCount / totalUserCount) * 100 : 0,
-        );
+        advancedGauges.periodicityWeekly.set(toPercent(weeklyPeriodicityCount, totalUserCount));
+        advancedGauges.periodicityMonthly.set(toPercent(monthlyPeriodicityCount, totalUserCount));
 
         // --- Combined Active/Unique Users by Email Domain (5min, 1d, 7d, 30d) ---
         const usersByDomainResults = await Message.aggregate([
@@ -592,7 +589,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
         for (const result of uniqueUsers30dByDomainAgg) {
             advancedGauges.userPercentByDomain30d.set(
                 { email_domain: result.domain },
-                totalUniqueUsers30d > 0 ? (result.count / totalUniqueUsers30d) * 100 : 0,
+                toPercent(result.count, totalUniqueUsers30d),
             );
         }
 
@@ -855,33 +852,40 @@ export async function updateAdvancedMetrics(): Promise<void> {
             totalAssistantMessages30d += total;
             totalFeedbackMessages30d += result.thumbsUp + result.thumbsDown;
 
-            const upPct = (result.thumbsUp / total) * 100;
-            const downPct = (result.thumbsDown / total) * 100;
-            const netSatisfaction = ((result.thumbsUp - result.thumbsDown) / total) * 100;
+            const upPct = toPercent(result.thumbsUp, total);
+            const downPct = toPercent(result.thumbsDown, total);
+            const netSatisfaction = toPercent(result.thumbsUp - result.thumbsDown, total);
 
-            if (id.startsWith('agent_')) {
-                const displayName = agentMap.get(id) || id;
-                advancedGauges.feedbackThumbsUpPercentByAgent30d.set({ agent: displayName }, upPct);
-                advancedGauges.feedbackThumbsDownPercentByAgent30d.set({ agent: displayName }, downPct);
-                advancedGauges.netSatisfactionByAgent30d.set({ agent: displayName }, netSatisfaction);
-            } else if (!id.startsWith('assistant_')) {
-                advancedGauges.feedbackThumbsUpPercentByModel30d.set({ model: id }, upPct);
-                advancedGauges.feedbackThumbsDownPercentByModel30d.set({ model: id }, downPct);
-                advancedGauges.netSatisfactionByModel30d.set({ model: id }, netSatisfaction);
+            const entityType = id.split('_')[0];
+            switch (entityType) {
+                case 'agent': {
+                    const displayName = agentMap.get(id) || id;
+                    advancedGauges.feedbackThumbsUpPercentByAgent30d.set({ agent: displayName }, upPct);
+                    advancedGauges.feedbackThumbsDownPercentByAgent30d.set({ agent: displayName }, downPct);
+                    advancedGauges.netSatisfactionByAgent30d.set({ agent: displayName }, netSatisfaction);
+                    break;
+                }
+                case 'assistant':
+                    // add for future assistant metrics
+                    break;
+                // had to be defaults as model have different naming conventions and we want to capture all models even if they don't follow a strict pattern
+                default:
+                    advancedGauges.feedbackThumbsUpPercentByModel30d.set({ model: id }, upPct);
+                    advancedGauges.feedbackThumbsDownPercentByModel30d.set({ model: id }, downPct);
+                    advancedGauges.netSatisfactionByModel30d.set({ model: id }, netSatisfaction);
+                    break;
             }
         }
 
         // Feedback engagement rate: % of assistant messages that received any feedback
         advancedGauges.feedbackEngagementRate30d.set(
-            totalAssistantMessages30d > 0
-                ? (totalFeedbackMessages30d / totalAssistantMessages30d) * 100
-                : 0,
+            toPercent(totalFeedbackMessages30d, totalAssistantMessages30d),
         );
 
         // --- Distinct Deployed Model Names ---
         const filteredDistinctModels = distinctModelsAgg.filter((doc: { _id: string }) => {
-            const id: string = doc._id;
-            return !id.startsWith('agent_') && !id.startsWith('assistant_');
+            const id: string = doc._id;          
+            return !id.startsWith('agent_') && !id.startsWith('assistant_');     
         });
         advancedGauges.deployedModelNamesCount.set(filteredDistinctModels.length);
 
@@ -899,9 +903,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
         }
 
         advancedGauges.mcpUniqueUserCount30d.set(mcpUsers);
-        advancedGauges.mcpUtilizationPercent30d.set(
-            totalToolCalls30d > 0 ? (mcpTotal / totalToolCalls30d) * 100 : 0,
-        );
+        advancedGauges.mcpUtilizationPercent30d.set(toPercent(mcpTotal, totalToolCalls30d));
 
         console.log('Advanced metrics updated.');
     } catch (error) {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -884,8 +884,8 @@ export async function updateAdvancedMetrics(): Promise<void> {
 
         // --- Distinct Deployed Model Names ---
         const filteredDistinctModels = distinctModelsAgg.filter((doc: { _id: string }) => {
-            const id: string = doc._id;          
-            return !id.startsWith('agent_') && !id.startsWith('assistant_');     
+            const id: string = doc._id;
+            return !id.startsWith('agent_') && !id.startsWith('assistant_');
         });
         advancedGauges.deployedModelNamesCount.set(filteredDistinctModels.length);
 

--- a/src/metrics/basicMetrics.ts
+++ b/src/metrics/basicMetrics.ts
@@ -82,7 +82,6 @@ export async function updateBasicMetrics(): Promise<void> {
             Message.countDocuments({}),
             PluginAuth.countDocuments({}),
             Preset.countDocuments({}),
-            //Project.countDocuments({}),
             PromptGroup.countDocuments({}),
             Prompt.countDocuments({}),
             Session.countDocuments({}),

--- a/src/metrics/basicMetrics.ts
+++ b/src/metrics/basicMetrics.ts
@@ -13,7 +13,6 @@ import {
     Message,
     PluginAuth,
     Preset,
-    Project,
     PromptGroup,
     Prompt,
     Session,
@@ -37,7 +36,6 @@ export const basicGauges = {
     messages: new client.Gauge({ name: 'librechat_message_count', help: 'Total number of messages' }),
     pluginAuth: new client.Gauge({ name: 'librechat_plugin_auth_count', help: 'Total number of plugin auth records' }),
     presets: new client.Gauge({ name: 'librechat_preset_count', help: 'Total number of presets' }),
-    projects: new client.Gauge({ name: 'librechat_project_count', help: 'Total number of projects' }),
     promptGroups: new client.Gauge({ name: 'librechat_prompt_group_count', help: 'Total number of prompt groups' }),
     prompts: new client.Gauge({ name: 'librechat_prompt_count', help: 'Total number of prompts' }),
     sessions: new client.Gauge({ name: 'librechat_session_count', help: 'Total number of sessions' }),
@@ -63,7 +61,6 @@ export async function updateBasicMetrics(): Promise<void> {
             messageCount,
             pluginAuthCount,
             presetCount,
-            projectCount,
             promptGroupCount,
             promptCount,
             sessionCount,
@@ -85,7 +82,7 @@ export async function updateBasicMetrics(): Promise<void> {
             Message.countDocuments({}),
             PluginAuth.countDocuments({}),
             Preset.countDocuments({}),
-            Project.countDocuments({}),
+            //Project.countDocuments({}),
             PromptGroup.countDocuments({}),
             Prompt.countDocuments({}),
             Session.countDocuments({}),
@@ -107,7 +104,6 @@ export async function updateBasicMetrics(): Promise<void> {
         basicGauges.messages.set(messageCount);
         basicGauges.pluginAuth.set(pluginAuthCount);
         basicGauges.presets.set(presetCount);
-        basicGauges.projects.set(projectCount);
         basicGauges.promptGroups.set(promptGroupCount);
         basicGauges.prompts.set(promptCount);
         basicGauges.sessions.set(sessionCount);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -17,7 +17,6 @@ export const Key = models.Key;
 export const Message = models.Message;
 export const PluginAuth = models.PluginAuth;
 export const Preset = models.Preset;
-export const Project = models.Project;
 export const PromptGroup = models.PromptGroup;
 // Note: The original Prompt.ts file incorrectly used roleSchema to create a 'Role' model,
 // so we maintain the export name 'Prompt' for backward compatibility in metrics code


### PR DESCRIPTION
# Pull Request

## Description
This PR adds the following: 
* New metrics as displayed below

<img width="867" height="347" alt="image" src="https://github.com/user-attachments/assets/bef10133-8c52-4d0d-a23f-c12dc0316579" />
---
<img width="1068" height="745" alt="image" src="https://github.com/user-attachments/assets/3db6f780-65aa-48c2-978f-a805ee860ea1" />
---
<img width="1079" height="333" alt="image" src="https://github.com/user-attachments/assets/d8324e4d-e440-44b8-b9ea-71fb970144f9" />
---
<img width="857" height="87" alt="image" src="https://github.com/user-attachments/assets/fe8ac35d-b679-402a-9359-24b289445cd3" />
---
<img width="850" height="336" alt="image" src="https://github.com/user-attachments/assets/37c580f2-bb6f-4e7d-b3b0-51c6cc050997" />

---
<img width="778" height="232" alt="image" src="https://github.com/user-attachments/assets/eda8de7b-697d-4936-adc5-09222b23e9b8" />
---
<img width="828" height="134" alt="image" src="https://github.com/user-attachments/assets/fdbb482f-4191-4d14-894b-4685f13a30e9" />




## Feedback Metrics

| Metric Name | Labels | Description |
|---|---|---|
| `librechat_message_feedback_thumbs_up_total` | — | Total count of thumbs up feedback |
| `librechat_message_feedback_thumbs_down_total` | — | Total count of thumbs down feedback |
| `librechat_feedback_thumbs_up_percent_by_model_30d` | `model` | % of messages with thumbs up per model (last 30 days) |
| `librechat_feedback_thumbs_down_percent_by_model_30d` | `model` | % of messages with thumbs down per model (last 30 days) |
| `librechat_feedback_thumbs_up_percent_by_agent_30d` | `agent` | % of messages with thumbs up per agent (last 30 days) |
| `librechat_feedback_thumbs_down_percent_by_agent_30d` | `agent` | % of messages with thumbs down per agent (last 30 days) |
| `librechat_feedback_engagement_rate_30d` | — | % of assistant messages that received any feedback (last 30 days) |
| `librechat_net_satisfaction_by_model_30d` | `model` | Net satisfaction score per model: (thumbsUp − thumbsDown) / total × 100 (last 30 days) |
| `librechat_net_satisfaction_by_agent_30d` | `agent` | Net satisfaction score per agent: (thumbsUp − thumbsDown) / total × 100 (last 30 days) |

## User / Domain Metrics

| Metric Name | Labels | Description |
|---|---|---|
| `librechat_user_percent_by_email_domain_30d` | `email_domain` | % of active users by email domain (last 30 days) |

## Adoption Rate Metrics

| Metric Name | Labels | Description |
|---|---|---|
| `librechat_adoption_rate_7d` | — | % of active users (last 7 days) vs total registered users |
| `librechat_adoption_rate_30d` | — | % of active users (last 30 days) vs total registered users |

## Usage Periodicity Metrics

| Metric Name | Labels | Description |
|---|---|---|
| `librechat_periodicity_daily` | — | % of registered users active today (last 24h) |
| `librechat_periodicity_weekly` | — | % of registered users active 3+ days in the last 7 days |
| `librechat_periodicity_monthly` | — | % of registered users active 5+ days in the last 30 days |

## MCP Utilization Metrics (30 days)

| Metric Name | Labels | Description |
|---|---|---|
| `librechat_mcp_tool_call_count_30d` | — | Total MCP tool calls in the last 30 days |
| `librechat_mcp_tool_call_count_by_tool_30d` | `toolId` | MCP tool calls by tool in the last 30 days |
| `librechat_mcp_unique_users_30d` | — | Unique users using MCP tools in the last 30 days |
| `librechat_mcp_utilization_percent_30d` | — | % of tool calls that are MCP in the last 30 days |
